### PR TITLE
fixed usage of CancellationToken.Register

### DIFF
--- a/src/TextToSpeech.Plugin.iOSUnified/TextToSpeech.cs
+++ b/src/TextToSpeech.Plugin.iOSUnified/TextToSpeech.cs
@@ -159,12 +159,13 @@ namespace Plugin.TextToSpeech
             try
             {
                 currentSpeak = new TaskCompletionSource<object>();
-                cancelToken?.Register(() => TryCancel());
 
                 speechSynthesizer.DidFinishSpeechUtterance += this.OnFinishedSpeechUtterance;
                 speechSynthesizer.SpeakUtterance(speechUtterance);
-
-                await currentSpeak.Task;
+                using (cancelToken?.Register(TryCancel))
+                {
+                    await currentSpeak.Task;
+                }
             }
             finally
             {


### PR DESCRIPTION
This PR adds proper cleanup of CancellationTokenRegistations by wrapping `CancellationToken.Register()` into a using.

Because of the missing deregistration, you could end up with some memory leaks because of the captured closure in all `CancellationToken.Register()` and/or execute the registered action multiple times, if the user, passes the same CancellationToken.

see: [MSDN: How to: Register Callbacks for Cancellation Requests](https://msdn.microsoft.com/en-us/library/ee191554%28v=vs.110%29.aspx)