### PR TITLE
Removed the await on Line #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Build status:
 
 **Simple Text**
 ```csharp
-await CrossTextToSpeech.Current.Speak("Text to speak");
+CrossTextToSpeech.Current.Speak("Text to speak");
 ```
 
 **Advanced speech API**


### PR DESCRIPTION
CrossTextToSpeech.Current.Speak("Text to speak"); doesn't really require await.

Please take a moment to fill out the following:

Fixes # .

Changes Proposed in this pull request:
-
-
- 
