### PR TITLE
fixed usage of CancellationToken.Register

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ await CrossTextToSpeech.Current.Speak("Text to speak");
 /// <param name="speakRate">Speak Rate of voice (All) (0.0 - 2.0f)</param>
 /// <param name="volume">Volume of voice (iOS/WP) (0.0-1.0)</param>
 /// <param name="cancelToken">Cancel the current speech</param>
-public async Task Speak(string text, CrossLocale crossLocale = null, float? pitch = null, float? speakRate = null, float? volume = null, CancellationToken? cancelToken = null)
+public async Task Speak(string text, CrossLocale crossLocale = null, float? pitch = null, float? speakRate = null, float? volume = null, CancellationToken cancelToken = default(CancellationToken))
 ```  
 
 **CrossLocale**

--- a/src/TextToSpeech.Plugin.Abstractions/ITextToSpeech.cs
+++ b/src/TextToSpeech.Plugin.Abstractions/ITextToSpeech.cs
@@ -22,7 +22,7 @@ namespace Plugin.TextToSpeech.Abstractions
         /// <param name="cancelToken">Canelation token to stop speak</param> 
         /// <exception cref="ArgumentNullException">Thrown if text is null</exception>
         /// <exception cref="ArgumentException">Thrown if text length is greater than maximum allowed</exception>
-        Task Speak(string text, CrossLocale? crossLocale = null, float? pitch = null, float? speakRate = null, float? volume = null, CancellationToken? cancelToken = null);
+        Task Speak(string text, CrossLocale? crossLocale = null, float? pitch = null, float? speakRate = null, float? volume = null, CancellationToken cancelToken = default(CancellationToken));
 
 		/// <summary>
 		/// Get avalid list of installed languages for TTS


### PR DESCRIPTION
This PR adds proper cleanup of CancellationTokenRegistations by wrapping `CancellationToken.Register()` into a using.

Because of the missing deregistration, you could end up with some memory leaks because of the captured closure in all `CancellationToken.Register()` and/or execute the registered action multiple times, if the user, passes the same CancellationToken.

see: [MSDN: How to: Register Callbacks for Cancellation Requests](https://msdn.microsoft.com/en-us/library/ee191554%28v=vs.110%29.aspx)

I removed the nullability of `CancellationToken` because it adds unnecessary complexity.

**General Feedback:**
The idention style makes it hard to contribute, because there are different indentions (tabs and spaces) used across the code (even mixed up in the same file (e.g. ITextToSpeech.cs)). It would be nice, if you run a "apply codestyle" command on all files. It would remove trailing spaces as well. This will lead to cleaner diffs in pull requests.

See the difference:
![image](https://user-images.githubusercontent.com/7632775/28483240-8e05fa62-6e6c-11e7-8649-08192a524918.png)

