### PR TITLE
[TextToSpeechPlugin][ISSUE] : Fix the issue that the plugin always detects that TextToSpeech has not been initialized yet when calling GetInstalledLanguages() for the first time

### DIFF
--- a/src/TextToSpeech.Plugin.Android/TextToSpeech.cs
+++ b/src/TextToSpeech.Plugin.Android/TextToSpeech.cs
@@ -54,8 +54,8 @@ namespace Plugin.TextToSpeech
         {
             if (status.Equals(OperationResult.Success))
             {
+				initialized = true;
                 initTcs.TrySetResult(true);
-                initialized = true;
             }
             else
             {


### PR DESCRIPTION
Fix the issue that the plugin always detects that TextToSpeech has not been initialized yet when calling GetInstalledLanguages() for the first time

Please take a moment to fill out the following:

Fixes # .

Changes Proposed in this pull request:
-
-
- 
