### PR TITLE
Fixes #53 Validation for MaxSpeechInputLength

### DIFF
--- a/src/TextToSpeech.Plugin.Android/TextToSpeech.cs
+++ b/src/TextToSpeech.Plugin.Android/TextToSpeech.cs
@@ -82,7 +82,7 @@ namespace Plugin.TextToSpeech
             if (text == null)
                 throw new ArgumentNullException(nameof(text), "Text can not be null");
 
-            if (text.Length > MaxSpeechInputLength)
+            if (text.Length >= MaxSpeechInputLength)
                 throw new ArgumentException(nameof(text), "Text length is over the maximum speech input length.");
 
             try


### PR DESCRIPTION
Fixes #53 .

Changes Proposed in this pull request:
- Ajust the validation against MaxSpeechInputLength according to it [TextToSpeech's underlying Java implementation](https://github.com/aosp-mirror/platform_frameworks_base/blob/master/core/java/android/speech/tts/TextToSpeechService.java#L993) 